### PR TITLE
Add codeclimate repository resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 terraform-provider-codeclimate
 
 bin/
+
+# idea
+.idea

--- a/README.md
+++ b/README.md
@@ -58,11 +58,9 @@ data "codeclimate_organization" "babbel" {
 }
 
 resource "codeclimate_repository" "codeclimate_terraform_test" {
-
   repository_url  = "https://github.com/babbel/codeclimate_terraform_test"
   organization_id = data.codeclimate_organization.babbel.id
 }
-
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ data "codeclimate_organization" "babbel" {
 }
 ```
 
-Create codeclimate repository 
+Create codeclimate repository
 
 ```hcl
 provider "codeclimate" {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently the provider supports just retreaving the repository as data source.
 
 ```hcl
 provider "codeclimate" {
-  api_key = "${var.api_key}"
+  api_key = "${var.api_key}"        # Will fallback to CODECLIMATE_TOKEN environment variable if not explicitly specified.
 }
 
 data "codeclimate_repository" "test" {

--- a/README.md
+++ b/README.md
@@ -34,6 +34,37 @@ data "codeclimate_repository" "test" {
 }
 ```
 
+Get organization information
+
+```hcl
+provider "codeclimate" {
+  api_key = "${var.api_key}"
+}
+
+data "codeclimate_organization" "babbel" {
+  name = "babbel"
+}
+```
+
+Create codeclimate repository 
+
+```hcl
+provider "codeclimate" {
+  api_key = "${var.api_key}"
+}
+
+data "codeclimate_organization" "babbel" {
+  name = "babbel"
+}
+
+resource "codeclimate_repository" "codeclimate_terraform_test" {
+
+  repository_url  = "https://github.com/babbel/codeclimate_terraform_test"
+  organization_id = data.codeclimate_organization.babbel.id
+}
+
+```
+
 Developing the Provider
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ resource "codeclimate_repository" "codeclimate_terraform_test" {
 
 ```
 
+
+Importing repository
+
+```
+terraform import codeclimate_repository.codeclimate_terraform_test babbel/codeclimate_terraform_test
+```
+
+
 Developing the Provider
 ---------------------------
 

--- a/codeclimate/data_source_organization.go
+++ b/codeclimate/data_source_organization.go
@@ -1,0 +1,38 @@
+package codeclimate
+
+import (
+	"github.com/babbel/terraform-provider-codeclimate/codeclimateclient"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceOrganization() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceOrganizationRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceOrganizationRead(d *schema.ResourceData, client interface{}) error {
+	organizationName := d.Get("name").(string)
+
+	c := client.(*codeclimateclient.Client)
+	organization, err := c.GetOrganization(organizationName)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(organization.Id)
+	err = d.Set("name", organization.Name)
+
+	return err
+}

--- a/codeclimate/provider.go
+++ b/codeclimate/provider.go
@@ -18,7 +18,11 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"codeclimate_repository": dataSourceRepository(),
+			"codeclimate_repository":   dataSourceRepository(),
+			"codeclimate_organization": dataSourceOrganization(),
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"codeclimate_repository": resourceRepository(),
 		},
 		ConfigureFunc: configureProvider,
 	}

--- a/codeclimate/provider.go
+++ b/codeclimate/provider.go
@@ -14,6 +14,7 @@ func Provider() terraform.ResourceProvider {
 			"api_key": {
 				Type:        schema.TypeString,
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CODECLIMATE_TOKEN", nil),
 				Description: "Token for the CodeClimate API.",
 			},
 		},

--- a/codeclimate/provider.go
+++ b/codeclimate/provider.go
@@ -24,6 +24,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"codeclimate_repository": resourceRepository(),
 		},
+
 		ConfigureFunc: configureProvider,
 	}
 }

--- a/codeclimate/resource_repository.go
+++ b/codeclimate/resource_repository.go
@@ -52,6 +52,14 @@ func resourceRepositoryRead(d *schema.ResourceData, client interface{}) error {
 		return err
 	}
 	err = d.Set("codeclimate_id", repository.Id)
+	if err != nil {
+		return err
+	}
+	err = d.Set("repository_url", repository.RepositoryURL)
+	if err != nil {
+		return err
+	}
+	err = d.Set("organization_id", repository.Organization)
 	return err
 }
 

--- a/codeclimate/resource_repository.go
+++ b/codeclimate/resource_repository.go
@@ -48,8 +48,10 @@ func resourceRepositoryRead(d *schema.ResourceData, client interface{}) error {
 
 	d.SetId(repositorySlug)
 	err = d.Set("test_reporter_id", repository.TestReporterId)
+	if err != nil {
+		return err
+	}
 	err = d.Set("codeclimate_id", repository.Id)
-
 	return err
 }
 

--- a/codeclimate/resource_repository.go
+++ b/codeclimate/resource_repository.go
@@ -1,7 +1,6 @@
 package codeclimate
 
 import (
-	"fmt"
 	"github.com/babbel/terraform-provider-codeclimate/codeclimateclient"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -38,10 +37,6 @@ func resourceRepository() *schema.Resource {
 	}
 }
 
-func resourceRepositoryDelete(data *schema.ResourceData, i interface{}) error {
-	return fmt.Errorf("delete repository is not supported yet")
-}
-
 func resourceRepositoryRead(d *schema.ResourceData, client interface{}) error {
 	repositorySlug := d.Id()
 
@@ -75,6 +70,20 @@ func resourceRepositoryCreateForOrganization(d *schema.ResourceData, client inte
 		return err
 	}
 	err = d.Set("codeclimate_id", repository.Id)
+
+	return err
+}
+
+func resourceRepositoryDelete(d *schema.ResourceData, client interface{}) error {
+	repositoryID := d.Get("codeclimate_id").(string)
+
+	c := client.(*codeclimateclient.Client)
+	err := c.DeleteOrganizationRepository(repositoryID)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
 
 	return err
 }

--- a/codeclimate/resource_repository.go
+++ b/codeclimate/resource_repository.go
@@ -1,0 +1,75 @@
+package codeclimate
+
+import (
+	"fmt"
+	"github.com/babbel/terraform-provider-codeclimate/codeclimateclient"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceRepository() *schema.Resource {
+	return &schema.Resource{
+		Read:   resourceRepositoryRead,
+		Create: resourceRepositoryCreateForOrganization,
+		Delete: resourceRepositoryDelete,
+
+		Schema: map[string]*schema.Schema{
+			"repository_slug": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"test_reporter_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"repository_url": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"organization_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceRepositoryDelete(data *schema.ResourceData, i interface{}) error {
+	return fmt.Errorf("delete repository is not supported yet")
+}
+
+func resourceRepositoryRead(d *schema.ResourceData, client interface{}) error {
+	repositorySlug := d.Get("repository_slug").(string)
+
+	c := client.(*codeclimateclient.Client)
+	repository, err := c.GetRepository(repositorySlug)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(repository.Id)
+	err = d.Set("test_reporter_id", repository.TestReporterId)
+	return err
+}
+
+func resourceRepositoryCreateForOrganization(d *schema.ResourceData, client interface{}) error {
+	repositoryUrl := d.Get("repository_url").(string)
+	organizationId := d.Get("organization_id").(string)
+
+	c := client.(*codeclimateclient.Client)
+
+	repository, err := c.CreateOrganizationRepository(organizationId, repositoryUrl)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(repository.Id)
+	err = d.Set("test_reporter_id", repository.TestReporterId)
+	if err != nil {
+		return err
+	}
+	err = d.Set("repository_slug", repository.GithubSlug)
+
+	return err
+}

--- a/codeclimate/resource_repository.go
+++ b/codeclimate/resource_repository.go
@@ -13,7 +13,7 @@ func resourceRepository() *schema.Resource {
 		Delete: resourceRepositoryDelete,
 
 		Schema: map[string]*schema.Schema{
-			"repository_slug": {
+			"codeclimate_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -32,6 +32,9 @@ func resourceRepository() *schema.Resource {
 				ForceNew: true,
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 
@@ -40,7 +43,7 @@ func resourceRepositoryDelete(data *schema.ResourceData, i interface{}) error {
 }
 
 func resourceRepositoryRead(d *schema.ResourceData, client interface{}) error {
-	repositorySlug := d.Get("repository_slug").(string)
+	repositorySlug := d.Id()
 
 	c := client.(*codeclimateclient.Client)
 	repository, err := c.GetRepository(repositorySlug)
@@ -48,8 +51,10 @@ func resourceRepositoryRead(d *schema.ResourceData, client interface{}) error {
 		return err
 	}
 
-	d.SetId(repository.Id)
+	d.SetId(repositorySlug)
 	err = d.Set("test_reporter_id", repository.TestReporterId)
+	err = d.Set("codeclimate_id", repository.Id)
+
 	return err
 }
 
@@ -64,12 +69,12 @@ func resourceRepositoryCreateForOrganization(d *schema.ResourceData, client inte
 		return err
 	}
 
-	d.SetId(repository.Id)
+	d.SetId(repository.GithubSlug)
 	err = d.Set("test_reporter_id", repository.TestReporterId)
 	if err != nil {
 		return err
 	}
-	err = d.Set("repository_slug", repository.GithubSlug)
+	err = d.Set("codeclimate_id", repository.Id)
 
 	return err
 }

--- a/codeclimateclient/client.go
+++ b/codeclimateclient/client.go
@@ -2,6 +2,7 @@ package codeclimateclient
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
@@ -12,16 +13,17 @@ type Client struct {
 }
 
 // TODO: Extend in the future to accept POST requests
-func (c *Client) makeRequest(path string) ([]byte, error) {
+func (c *Client) makeRequest(method string, path string, payload io.Reader) ([]byte, error) {
 	client := &http.Client{}
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", c.BaseUrl, path), nil)
+	req, err := http.NewRequest(method, fmt.Sprintf("%s/%s", c.BaseUrl, path), payload)
 
 	if err != nil {
 		return nil, err
 	}
 
 	req.Header.Add("Accept", "application/vnd.api+json")
+	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Token token=%s", c.ApiKey))
 
 	resp, err := client.Do(req)

--- a/codeclimateclient/organization.go
+++ b/codeclimateclient/organization.go
@@ -1,0 +1,46 @@
+package codeclimateclient
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Organization struct {
+	Id   string
+	Name string
+}
+
+type readOrganizationsResponse struct {
+	Data []struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			Name string `json:"name"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+func (client *Client) GetOrganization(organizationName string) (*Organization, error) {
+	var organizationsData readOrganizationsResponse
+
+	data, err := client.makeRequest(http.MethodGet, "orgs", nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(data, &organizationsData)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, org := range organizationsData.Data {
+		if org.Attributes.Name == organizationName {
+			organization := &Organization{
+				Id:   org.ID,
+				Name: org.Attributes.Name,
+			}
+			return organization, nil
+		}
+	}
+	return nil, nil
+}

--- a/codeclimateclient/organization.go
+++ b/codeclimateclient/organization.go
@@ -2,6 +2,7 @@ package codeclimateclient
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -42,5 +43,5 @@ func (client *Client) GetOrganization(organizationName string) (*Organization, e
 			return organization, nil
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("The Organization could not be found")
 }

--- a/codeclimateclient/organization_test.go
+++ b/codeclimateclient/organization_test.go
@@ -1,0 +1,33 @@
+package codeclimateclient
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+const (
+	organizationName           = "testorg2"
+	expectedTestOrganizationId = "5f2176144f78f5011f002a89"
+)
+
+func TestOrganizationGetId(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, getFixture("organizations/organizations.json"))
+	})
+
+	organization, err := client.GetOrganization(organizationName)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if organization.Id != expectedTestOrganizationId {
+		t.Errorf("Expected organization_id to be '%s', got: '%s'", expectedTestOrganizationId, organization.Id)
+	}
+}

--- a/codeclimateclient/repository.go
+++ b/codeclimateclient/repository.go
@@ -3,28 +3,49 @@ package codeclimateclient
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
 )
 
 type Repository struct {
 	Id             string
 	TestReporterId string
+	GithubSlug     string
 }
 
 // The structure describes just what we need from the response.
 //  For the full description look at: https://developer.codeclimate.com/?shell#get-repository
-type readRepositoryResponse struct {
+type readRepositoriesResponse struct {
 	Data []struct {
 		ID         string `json:"id"`
 		Attributes struct {
 			TestReporterID string `json:"test_reporter_id"`
+			GithubSlug     string `json:"github_slug"`
 		} `json:"attributes"`
 	} `json:"data"`
 }
 
-func (client *Client) GetRepository(repositorySlug string) (*Repository, error) {
-	var repositoryData readRepositoryResponse
+type createRepositoryResponse struct {
+	Data struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			TestReporterID string `json:"test_reporter_id"`
+			GithubSlug     string `json:"github_slug"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
 
-	data, err := client.makeRequest(fmt.Sprintf("repos?github_slug=%s", repositorySlug))
+type errorResponse struct {
+	Errors []struct {
+		Detail string `json:"detail"`
+		Title  string `json:"title"`
+	} `json:"errors"`
+}
+
+func (client *Client) GetRepository(repositorySlug string) (*Repository, error) {
+	var repositoryData readRepositoriesResponse
+
+	data, err := client.makeRequest(http.MethodGet, fmt.Sprintf("repos?github_slug=%s", repositorySlug), nil)
 
 	if err != nil {
 		return nil, err
@@ -47,7 +68,55 @@ func (client *Client) GetRepository(repositorySlug string) (*Repository, error) 
 	repository := &Repository{
 		Id:             repositoryData.Data[0].ID,
 		TestReporterId: repositoryData.Data[0].Attributes.TestReporterID,
+		GithubSlug:     repositoryData.Data[0].Attributes.GithubSlug,
 	}
 
 	return repository, nil
+}
+
+func (client *Client) CreateOrganizationRepository(organizationID string, url string) (*Repository, error) {
+	var repositoryData createRepositoryResponse
+
+	payload := fmt.Sprintf(`
+		{
+			"data": {
+				"type": "repos",
+				"attributes": {
+					"url": "%s"
+				}
+			}
+		}`, url)
+
+	data, err := client.makeRequest(http.MethodPost, fmt.Sprintf("orgs/%s/repos", organizationID), strings.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(data, &repositoryData)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if repositoryData.Data.ID == "" {
+		return nil, handleErrorResponse(data)
+	}
+
+	repository := &Repository{
+		Id:             repositoryData.Data.ID,
+		TestReporterId: repositoryData.Data.Attributes.TestReporterID,
+		GithubSlug:     repositoryData.Data.Attributes.GithubSlug,
+	}
+
+	return repository, nil
+
+}
+
+func handleErrorResponse(data []byte) error {
+	var errorResponse errorResponse
+	err := json.Unmarshal(data, &errorResponse)
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("Invalid json response %s", errorResponse.Errors)
 }

--- a/codeclimateclient/repository.go
+++ b/codeclimateclient/repository.go
@@ -112,6 +112,16 @@ func (client *Client) CreateOrganizationRepository(organizationID string, url st
 
 }
 
+func (client *Client) DeleteOrganizationRepository(repositoryID string) error {
+	_, err := client.makeRequest(http.MethodDelete, fmt.Sprintf("repos/%s", repositoryID), nil)
+
+	if err != nil {
+		return fmt.Errorf("The repository couldn't be deleted: %s", err)
+	}
+
+	return nil
+}
+
 func handleErrorResponse(data []byte) error {
 	var errorResponse errorResponse
 	err := json.Unmarshal(data, &errorResponse)

--- a/codeclimateclient/repository.go
+++ b/codeclimateclient/repository.go
@@ -11,6 +11,8 @@ type Repository struct {
 	Id             string
 	TestReporterId string
 	GithubSlug     string
+	Organization   string
+	RepositoryURL  string
 }
 
 // The structure describes just what we need from the response.
@@ -21,7 +23,15 @@ type readRepositoriesResponse struct {
 		Attributes struct {
 			TestReporterID string `json:"test_reporter_id"`
 			GithubSlug     string `json:"github_slug"`
+			VCSHost        string `json:"vcs_host"`
 		} `json:"attributes"`
+		Relationships struct {
+			Account struct {
+				Data struct {
+					ID string `json:"id"`
+				} `json:"data"`
+			} `json:"account"`
+		} `json:"relationships"`
 	} `json:"data"`
 }
 
@@ -69,6 +79,8 @@ func (client *Client) GetRepository(repositorySlug string) (*Repository, error) 
 		Id:             repositoryData.Data[0].ID,
 		TestReporterId: repositoryData.Data[0].Attributes.TestReporterID,
 		GithubSlug:     repositoryData.Data[0].Attributes.GithubSlug,
+		Organization:   repositoryData.Data[0].Relationships.Account.Data.ID,
+		RepositoryURL:  repositoryData.Data[0].Attributes.VCSHost + "/" + repositoryData.Data[0].Attributes.GithubSlug,
 	}
 
 	return repository, nil

--- a/codeclimateclient/repository_test.go
+++ b/codeclimateclient/repository_test.go
@@ -7,11 +7,13 @@ import (
 )
 
 const (
-	repositorySlug         = "lessonnine/testarepo"
-	expectedTestReporterId = "0c89092bc2c088d667612ddd1a992ec62f643ded331f40783bcf6b847561234d"
+	repositorySlug         = "testorg/testarepo"
+	expectedTestReporterID = "0c89092bc2c088d667612ddd1a992ec62f643ded331f40783bcf6b847561234d"
+	organizationID         = "testorg"
+	repositoryUrl          = "https://github.com/testorg/testarepo"
 )
 
-func TestGetId(t *testing.T) {
+func TestClient_GetRepository(t *testing.T) {
 	teardown := setup()
 	defer teardown()
 
@@ -31,7 +33,36 @@ func TestGetId(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if repository.TestReporterId != expectedTestReporterId {
-		t.Errorf("Expected test_reporter_id to be '%s', got: '%s'", expectedTestReporterId, repository.TestReporterId)
+	if repository.TestReporterId != expectedTestReporterID {
+		t.Errorf("Expected test_reporter_id to be '%s', got: '%s'", expectedTestReporterID, repository.TestReporterId)
+	}
+
+	if repository.GithubSlug != repositorySlug {
+		t.Errorf("Expected github slug to be '%s', got: '%s'", repositorySlug, repository.GithubSlug)
+	}
+}
+
+func TestClient_CreateOrganizationRepository(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("/orgs/%s/repos", organizationID), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, getFixture("repositories/create_repository_response.json"))
+	})
+
+	repository, err := client.CreateOrganizationRepository(organizationID, repositoryUrl)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if repository.TestReporterId != expectedTestReporterID {
+		t.Errorf("Expected test_reporter_id to be '%s', got: '%s'", expectedTestReporterID, repository.TestReporterId)
+	}
+
+	if repository.GithubSlug != repositorySlug {
+		t.Errorf("Expected github slug to be '%s', got: '%s'", repositorySlug, repository.GithubSlug)
 	}
 }

--- a/codeclimateclient/repository_test.go
+++ b/codeclimateclient/repository_test.go
@@ -11,6 +11,7 @@ const (
 	expectedTestReporterID = "0c89092bc2c088d667612ddd1a992ec62f643ded331f40783bcf6b847561234d"
 	organizationID         = "testorg"
 	repositoryUrl          = "https://github.com/testorg/testarepo"
+	repositoryID           = "696a76232df2736347000001"
 )
 
 func TestClient_GetRepository(t *testing.T) {
@@ -19,7 +20,7 @@ func TestClient_GetRepository(t *testing.T) {
 
 	mux.HandleFunc("/repos", func(w http.ResponseWriter, r *http.Request) {
 		if r.FormValue("github_slug") != repositorySlug {
-			t.Fatal(fmt.Errorf("received slug doesn match `%s`", repositorySlug))
+			t.Fatal(fmt.Errorf("received slug doesnt match `%s`", repositorySlug))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -65,4 +66,19 @@ func TestClient_CreateOrganizationRepository(t *testing.T) {
 	if repository.GithubSlug != repositorySlug {
 		t.Errorf("Expected github slug to be '%s', got: '%s'", repositorySlug, repository.GithubSlug)
 	}
+}
+func TestClient_DeleteOrganizationRepository(t *testing.T) {
+	teardown := setup()
+	defer teardown()
+
+	mux.HandleFunc(fmt.Sprintf("repos/%s", repositoryID), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.DeleteOrganizationRepository(repositoryID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
 }

--- a/codeclimateclient/testdata/fixtures/organizations/organizations.json
+++ b/codeclimateclient/testdata/fixtures/organizations/organizations.json
@@ -1,0 +1,35 @@
+{
+  "data": [
+    {
+      "id": "5be2f19ed0107402c20021bf",
+      "type": "orgs",
+      "attributes": {
+        "name": "testorg1"
+      },
+      "meta": {
+        "counts": {
+          "repos": 37
+        },
+        "permissions": {
+          "admin": true
+        }
+      }
+    },
+    {
+      "id": "5f2176144f78f5011f002a89",
+      "type": "orgs",
+      "attributes": {
+        "name": "testorg2"
+      },
+      "meta": {
+        "counts": {
+          "repos": 1
+        },
+        "permissions": {
+          "admin": true
+        }
+      }
+    }
+  ],
+  "links": {}
+}

--- a/codeclimateclient/testdata/fixtures/repositories/create_repository_response.json
+++ b/codeclimateclient/testdata/fixtures/repositories/create_repository_response.json
@@ -1,0 +1,57 @@
+{
+  "data": {
+    "id": "5b6abdc65b6abdc65b6abdc6",
+    "type": "repos",
+    "attributes": {
+      "analysis_version": 51450,
+      "badge_token": "d6dd39dd84d8575d1ddd",
+      "branch": "master",
+      "created_at": "2019-02-14T10:49:44.319Z",
+      "delegated_config_repo_id": "",
+      "diff_coverage_enforced": true,
+      "diff_coverage_threshold": 50,
+      "enable_notifications": true,
+      "github_slug": "testorg/testarepo",
+      "human_name": "testarepo",
+      "last_activity_at": "2019-04-24T15:14:09.719Z",
+      "test_reporter_id": "0c89092bc2c088d667612ddd1a992ec62f643ded331f40783bcf6b847561234d",
+      "total_coverage_enforced": true,
+      "vcs_database_id": "170111000",
+      "vcs_host": "https://github.com",
+      "score": null
+    },
+    "relationships": {
+      "latest_default_branch_snapshot": {
+        "data": {
+          "id": "5cc07d3643131c000101372f",
+          "type": "snapshots"
+        }
+      },
+      "latest_default_branch_test_report": {
+        "data": {
+          "id": "5cc07da55941051a3400872a",
+          "type": "test_reports"
+        }
+      },
+      "account": {
+        "data": {
+          "id": "52526f7356b102306b01a594",
+          "type": "orgs"
+        }
+      }
+    },
+    "links": {
+      "self": "https://codeclimate.com/repos/5b6abdc65b6abdc65b6abdc6",
+      "services": "https://api.codeclimate.com/v1/repos/5b6abdc65b6abdc65b6abdc6/services",
+      "web_coverage": "https://codeclimate.com/repos/5b6abdc65b6abdc65b6abdc6/coverage",
+      "web_issues": "https://codeclimate.com/repos/5b6abdc65b6abdc65b6abdc6/issues",
+      "maintainability_badge": "https://api.codeclimate.com/v1/badges/d6dd39dd84d8575d1ddd/maintainability",
+      "test_coverage_badge": "https://api.codeclimate.com/v1/badges/d6dd39dd84d8575d1ddd/test_coverage"
+    },
+    "meta": {
+      "permissions": {
+        "admin": true
+      }
+    }
+  }
+}

--- a/codeclimateclient/testdata/fixtures/repositories/repository.json
+++ b/codeclimateclient/testdata/fixtures/repositories/repository.json
@@ -12,7 +12,7 @@
         "diff_coverage_enforced": true,
         "diff_coverage_threshold": 50,
         "enable_notifications": true,
-        "github_slug": "lessonnine/testarepo",
+        "github_slug": "testorg/testarepo",
         "human_name": "testarepo",
         "last_activity_at": "2019-04-24T15:14:09.719Z",
         "test_reporter_id": "0c89092bc2c088d667612ddd1a992ec62f643ded331f40783bcf6b847561234d",

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -90,6 +91,7 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-plugin v1.0.1 h1:4OtAfUGbnKC6yS48p0CtMX2oFYtzFZVv6rok3cRWgnE=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
+github.com/hashicorp/go-plugin v1.2.0 h1:CUfYokW0EJNDcGecVrHZK//Cp1GFlHwoqtcUIEiU6BY=
 github.com/hashicorp/go-plugin v1.2.0/go.mod h1:F9eH4LrE/ZsRdbwhfjs9k9HoDUwAHnYtXdgmf1AVNs0=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
@@ -239,6 +241,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb h1:TR699M2v0qoKTOHxeLgp6zPqaQNs74f01a/ob9W0qko=
 golang.org/x/net v0.0.0-20191009170851-d66e71096ffb/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
@@ -264,6 +267,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa h1:KIDDMLT1O0Nr7TSxp8xM5tJcdn8tgyAONntO829og1M=
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -303,6 +307,7 @@ google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 h1:gSJIx1SDwno+2ElGhA4+qG2zF97qiUzTM+rQ0klBOcE=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
+google.golang.org/genproto v0.0.0-20200310143817-43be25429f5a h1:lRlI5zu6AFy3iU/F8YWyNrAmn/tPCnhiTxfwhWb76eU=
 google.golang.org/genproto v0.0.0-20200310143817-43be25429f5a/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
@@ -312,6 +317,7 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Hello,

We are integrating code climate with our terraform setup. In order to do that we decided to implement the repository resource (create, delete and import) and also the capability to read organisation in code climate.

What this PR contains:
*Read Organisation*
```
data "codeclimate_organization" "babbel" {
  name = "babbel"
}
```
*Create/Delete repository*
```
resource "codeclimate_repository" "codeclimate_terraform_test" {

  repository_url  = "https://github.com/babbel/codeclimate_terraform_test"
  organization_id = data.codeclimate_organization.babbel.id
}

```
*Import Repository*
```
terraform import codeclimate_repository.codeclimate_terraform_test babbel/codeclimate_terraform_test
```

We would like to keep the work on this provider under your repository since you originally created it, however it would be nice that you tell us if you are able to be the main maintainers or not since for us this is a quite important integration.

Also I would like to request to create a release and publish the binaries for that release once we get this PR merged (something like [this](https://github.com/mrolla/terraform-provider-circleci/releases/tag/v0.3.0), we only need binary for darwin-amd64 and linux-amd64) . Is it possible? 🙂 

By the way, this PR is replacing Fabio initial work on this [PR](https://github.com/babbel/terraform-provider-codeclimate/pull/24), so feel free to close it.

Thank you very much. 